### PR TITLE
Analyze pool and devcontainer changes

### DIFF
--- a/src/utils/devContainerUtils.ts
+++ b/src/utils/devContainerUtils.ts
@@ -202,7 +202,7 @@ RUN sudo mkdir -p -m 755 /etc/apt/keyrings \\
     && sudo apt install gh -y
 
 # Install playwright
-npx playwright install --with-deps
+RUN npx playwright install --with-deps
 
 # Install PM2 globally and ensure it's accessible
 RUN npm install -g pm2 && \\


### PR DESCRIPTION
```
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fix Dockerfile syntax error for Playwright installation to enable successful container builds.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The `npx playwright install --with-deps` command was missing a `RUN` instruction in the Dockerfile, causing Docker builds to fail and pools to remain in a pending state. This change corrects the syntax.
```

---
<a href="https://cursor.com/background-agent?bcId=bc-5d4be16f-4d0b-4adc-88b4-36e0da003d7d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5d4be16f-4d0b-4adc-88b4-36e0da003d7d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

